### PR TITLE
swift native ad sample use cocoapods

### DIFF
--- a/sample/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/sample/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.pbxproj
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.pbxproj
@@ -1,0 +1,419 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E8202EAD20D7CFD400EFE990 /* GNQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8202EAC20D7CFD400EFE990 /* GNQueue.swift */; };
+		E8202EB020D7D03900EFE990 /* MyCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8202EAF20D7D03900EFE990 /* MyCellData.swift */; };
+		E8202EB220D7D58900EFE990 /* TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8202EB120D7D58900EFE990 /* TableViewCell.swift */; };
+		E8202EB420D7D65200EFE990 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8202EB320D7D65200EFE990 /* TableViewController.swift */; };
+		E8CD32FE20D7C9CB00BFE623 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8CD32FD20D7C9CB00BFE623 /* AppDelegate.swift */; };
+		E8CD330320D7C9CB00BFE623 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E8CD330120D7C9CB00BFE623 /* Main.storyboard */; };
+		E8CD330520D7C9CD00BFE623 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E8CD330420D7C9CD00BFE623 /* Assets.xcassets */; };
+		E8CD330820D7C9CD00BFE623 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E8CD330620D7C9CD00BFE623 /* LaunchScreen.storyboard */; };
+		E9E32067803B84D5CE06710F /* libPods-GNAdSampleNativeAd.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 26DFA903BEF0974259679998 /* libPods-GNAdSampleNativeAd.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		26DFA903BEF0974259679998 /* libPods-GNAdSampleNativeAd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-GNAdSampleNativeAd.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A39E7A756A6B32A09CBF3CC /* Pods-GNAdSampleNativeAd.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GNAdSampleNativeAd.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GNAdSampleNativeAd/Pods-GNAdSampleNativeAd.debug.xcconfig"; sourceTree = "<group>"; };
+		7EC1A5635BDFC0EEB09C1545 /* Pods-GNAdSampleNativeAd.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GNAdSampleNativeAd.release.xcconfig"; path = "Pods/Target Support Files/Pods-GNAdSampleNativeAd/Pods-GNAdSampleNativeAd.release.xcconfig"; sourceTree = "<group>"; };
+		E8202EAC20D7CFD400EFE990 /* GNQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GNQueue.swift; sourceTree = "<group>"; };
+		E8202EAF20D7D03900EFE990 /* MyCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCellData.swift; sourceTree = "<group>"; };
+		E8202EB120D7D58900EFE990 /* TableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCell.swift; sourceTree = "<group>"; };
+		E8202EB320D7D65200EFE990 /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+		E8CD32FA20D7C9CB00BFE623 /* GNAdSampleNativeAd.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GNAdSampleNativeAd.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8CD32FD20D7C9CB00BFE623 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		E8CD330220D7C9CB00BFE623 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E8CD330420D7C9CD00BFE623 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E8CD330720D7C9CD00BFE623 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E8CD330920D7C9CD00BFE623 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E8CD330F20D7CBF700BFE623 /* GNAdSampleNativeAd-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "GNAdSampleNativeAd-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E8CD32F720D7C9CB00BFE623 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E9E32067803B84D5CE06710F /* libPods-GNAdSampleNativeAd.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7AB1BC2F58C4837AA36B9778 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				26DFA903BEF0974259679998 /* libPods-GNAdSampleNativeAd.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E295435A8A9AA1602FFD1BAD /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4A39E7A756A6B32A09CBF3CC /* Pods-GNAdSampleNativeAd.debug.xcconfig */,
+				7EC1A5635BDFC0EEB09C1545 /* Pods-GNAdSampleNativeAd.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		E8202EAB20D7CFA600EFE990 /* DataStructure */ = {
+			isa = PBXGroup;
+			children = (
+				E8202EAC20D7CFD400EFE990 /* GNQueue.swift */,
+			);
+			path = DataStructure;
+			sourceTree = "<group>";
+		};
+		E8202EAE20D7D01900EFE990 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				E8202EAF20D7D03900EFE990 /* MyCellData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		E8CD32F120D7C9CB00BFE623 = {
+			isa = PBXGroup;
+			children = (
+				E8CD32FC20D7C9CB00BFE623 /* GNAdSampleNativeAd */,
+				E8CD32FB20D7C9CB00BFE623 /* Products */,
+				E295435A8A9AA1602FFD1BAD /* Pods */,
+				7AB1BC2F58C4837AA36B9778 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		E8CD32FB20D7C9CB00BFE623 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E8CD32FA20D7C9CB00BFE623 /* GNAdSampleNativeAd.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E8CD32FC20D7C9CB00BFE623 /* GNAdSampleNativeAd */ = {
+			isa = PBXGroup;
+			children = (
+				E8202EAE20D7D01900EFE990 /* Models */,
+				E8202EAB20D7CFA600EFE990 /* DataStructure */,
+				E8CD32FD20D7C9CB00BFE623 /* AppDelegate.swift */,
+				E8CD330120D7C9CB00BFE623 /* Main.storyboard */,
+				E8CD330420D7C9CD00BFE623 /* Assets.xcassets */,
+				E8CD330620D7C9CD00BFE623 /* LaunchScreen.storyboard */,
+				E8CD330920D7C9CD00BFE623 /* Info.plist */,
+				E8CD330F20D7CBF700BFE623 /* GNAdSampleNativeAd-Bridging-Header.h */,
+				E8202EB120D7D58900EFE990 /* TableViewCell.swift */,
+				E8202EB320D7D65200EFE990 /* TableViewController.swift */,
+			);
+			path = GNAdSampleNativeAd;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E8CD32F920D7C9CB00BFE623 /* GNAdSampleNativeAd */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8CD330C20D7C9CD00BFE623 /* Build configuration list for PBXNativeTarget "GNAdSampleNativeAd" */;
+			buildPhases = (
+				B335C07722FAA0DDCE5B76E5 /* [CP] Check Pods Manifest.lock */,
+				E8CD32F620D7C9CB00BFE623 /* Sources */,
+				E8CD32F720D7C9CB00BFE623 /* Frameworks */,
+				E8CD32F820D7C9CB00BFE623 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GNAdSampleNativeAd;
+			productName = GNAdSampleNativeAd;
+			productReference = E8CD32FA20D7C9CB00BFE623 /* GNAdSampleNativeAd.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E8CD32F220D7C9CB00BFE623 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0940;
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = Geniee;
+				TargetAttributes = {
+					E8CD32F920D7C9CB00BFE623 = {
+						CreatedOnToolsVersion = 9.4;
+					};
+				};
+			};
+			buildConfigurationList = E8CD32F520D7C9CB00BFE623 /* Build configuration list for PBXProject "GNAdSampleNativeAd" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E8CD32F120D7C9CB00BFE623;
+			productRefGroup = E8CD32FB20D7C9CB00BFE623 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E8CD32F920D7C9CB00BFE623 /* GNAdSampleNativeAd */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E8CD32F820D7C9CB00BFE623 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E8CD330820D7C9CD00BFE623 /* LaunchScreen.storyboard in Resources */,
+				E8CD330520D7C9CD00BFE623 /* Assets.xcassets in Resources */,
+				E8CD330320D7C9CB00BFE623 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B335C07722FAA0DDCE5B76E5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GNAdSampleNativeAd-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E8CD32F620D7C9CB00BFE623 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E8202EB220D7D58900EFE990 /* TableViewCell.swift in Sources */,
+				E8202EB420D7D65200EFE990 /* TableViewController.swift in Sources */,
+				E8CD32FE20D7C9CB00BFE623 /* AppDelegate.swift in Sources */,
+				E8202EAD20D7CFD400EFE990 /* GNQueue.swift in Sources */,
+				E8202EB020D7D03900EFE990 /* MyCellData.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		E8CD330120D7C9CB00BFE623 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E8CD330220D7C9CB00BFE623 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		E8CD330620D7C9CD00BFE623 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E8CD330720D7C9CD00BFE623 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		E8CD330A20D7C9CD00BFE623 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E8CD330B20D7C9CD00BFE623 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E8CD330D20D7C9CD00BFE623 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4A39E7A756A6B32A09CBF3CC /* Pods-GNAdSampleNativeAd.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RKMVWZ32F4;
+				INFOPLIST_FILE = GNAdSampleNativeAd/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.geniee.GNAdSampleNativeAd;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "GNAdSampleNativeAd/GNAdSampleNativeAd-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E8CD330E20D7C9CD00BFE623 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EC1A5635BDFC0EEB09C1545 /* Pods-GNAdSampleNativeAd.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = RKMVWZ32F4;
+				INFOPLIST_FILE = GNAdSampleNativeAd/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.geniee.GNAdSampleNativeAd;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "GNAdSampleNativeAd/GNAdSampleNativeAd-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E8CD32F520D7C9CB00BFE623 /* Build configuration list for PBXProject "GNAdSampleNativeAd" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8CD330A20D7C9CD00BFE623 /* Debug */,
+				E8CD330B20D7C9CD00BFE623 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8CD330C20D7C9CD00BFE623 /* Build configuration list for PBXNativeTarget "GNAdSampleNativeAd" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8CD330D20D7C9CD00BFE623 /* Debug */,
+				E8CD330E20D7C9CD00BFE623 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E8CD32F220D7C9CB00BFE623 /* Project object */;
+}

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:GNAdSampleNativeAd.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/AppDelegate.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  GNAdSampleNativeAd
+//
+//  Created by Tomoyasu Kouta on 2018/06/18.
+//  Copyright © 2018年 Geniee. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/AppDelegate.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/AppDelegate.swift
@@ -1,10 +1,5 @@
-//
 //  AppDelegate.swift
 //  GNAdSampleNativeAd
-//
-//  Created by Tomoyasu Kouta on 2018/06/18.
-//  Copyright © 2018年 Geniee. All rights reserved.
-//
 
 import UIKit
 

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Assets.xcassets/Contents.json
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Base.lproj/LaunchScreen.storyboard
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Base.lproj/Main.storyboard
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Base.lproj/Main.storyboard
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="YTH-vy-dl2">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="TGO-x9-kZs">
+            <objects>
+                <viewController id="VGO-iC-4nh" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="eMU-7i-XWR"/>
+                        <viewControllerLayoutGuide type="bottom" id="zvV-GH-hcv"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="veb-gP-fxI">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Geniee NativeAd Sample" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tPZ-Os-rTW">
+                                <rect key="frame" x="16" y="72" width="210" height="77"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="guc-PJ-3ZK"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="IQX-t8-Qsc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1772" y="187"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="d9T-hB-Dfn">
+            <objects>
+                <tableViewController id="RdJ-It-poh" customClass="TableViewController" customModule="GNAdSampleNativeAd" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="84" sectionHeaderHeight="22" sectionFooterHeight="22" id="QVb-Ou-qak">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <view key="tableFooterView" contentMode="scaleToFill" id="nuz-cd-kOL">
+                            <rect key="frame" x="0.0" y="106" width="375" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <subviews>
+                                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="iAh-PI-AII">
+                                    <rect key="frame" x="177.5" y="12" width="20" height="20"/>
+                                </activityIndicatorView>
+                            </subviews>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="centerY" secondItem="iAh-PI-AII" secondAttribute="centerY" id="Dsq-gG-W7m"/>
+                                <constraint firstAttribute="centerX" secondItem="iAh-PI-AII" secondAttribute="centerX" id="jUD-n1-GTi"/>
+                            </constraints>
+                        </view>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SampleDataCell" rowHeight="84" id="WL8-CA-X34" customClass="TableViewCell" customModule="GNAdSampleNativeAd" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="22" width="375" height="84"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WL8-CA-X34" id="1dn-Hq-R1X">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="83.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TsD-Rt-Cs7">
+                                            <rect key="frame" x="8" y="8" width="60" height="60"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Cell Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vhN-8i-lZE">
+                                            <rect key="frame" x="86" y="3" width="514" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Cell Description" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8LU-s3-5dB">
+                                            <rect key="frame" x="86" y="24" width="514" height="55"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="content" destination="8LU-s3-5dB" id="NJw-iw-sg6"/>
+                                    <outlet property="icon" destination="TsD-Rt-Cs7" id="MgK-Z8-qto"/>
+                                    <outlet property="title" destination="vhN-8i-lZE" id="bQY-Ga-ffz"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="RdJ-It-poh" id="ntq-0K-a1E"/>
+                            <outlet property="delegate" destination="RdJ-It-poh" id="9Jm-70-DVf"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="Zdz-JD-qMo"/>
+                    <connections>
+                        <outlet property="indicator" destination="iAh-PI-AII" id="wgi-JS-YMV"/>
+                        <segue destination="VGO-iC-4nh" kind="push" identifier="selectRow" id="wPr-sH-oFf"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1zZ-7e-zSq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1113" y="187"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Ksn-w7-iyY">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="YTH-vy-dl2" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pia-11-hPn">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="RdJ-It-poh" kind="relationship" relationship="rootViewController" id="xbm-7m-hkR"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pWI-Kz-raL" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="301" y="187"/>
+        </scene>
+    </scenes>
+</document>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/DataStructure/GNQueue.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/DataStructure/GNQueue.swift
@@ -1,0 +1,49 @@
+//
+//  GNQueue.swift
+//  GNAdSampleNativeAd
+//
+
+class GNQueue: NSObject {
+    var queue: NSMutableArray = []
+    var maxSize: Int = 0
+    
+    init(aMaxSize: Int) {
+        super.init()
+        maxSize = aMaxSize;
+    }
+    
+    func dequeue() -> Any? {
+        var headObject: Any?
+        objc_sync_enter(queue)
+        if (queue.count == 0) {
+            return nil
+        }
+        headObject = queue.object(at:0)
+        if (headObject != nil) {
+            queue.removeObject(at:0)
+        }
+        objc_sync_exit(queue)
+        return headObject;
+    }
+    
+    func enqueue(_ anObject: AnyObject?) {
+        objc_sync_enter(queue)
+        if (anObject == nil) {
+            return;
+        }
+        if (queue.count >= maxSize) {
+            queue.removeObject(at:0)
+        }
+        queue.add(anObject!)
+        objc_sync_exit(queue)
+    }
+    
+    func count()->Int {
+        var c:Int = 0;
+        objc_sync_enter(queue)
+        c = queue.count
+        objc_sync_exit(queue)
+        return c
+    }
+}
+

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/GNAdSampleNativeAd-Bridging-Header.h
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/GNAdSampleNativeAd-Bridging-Header.h
@@ -1,0 +1,2 @@
+#import <GNAdSDK/GNNativeAdRequest.h>
+#import <GNAdSDK/GNNativeAd.h>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Info.plist
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Models/MyCellData.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/Models/MyCellData.swift
@@ -1,0 +1,23 @@
+//
+//  MyCellData.swift
+//  GNAdSampleNativeAd
+//
+
+class MyCellData: NSObject {
+    var imgURL: URL
+    var title: NSString
+    var content: NSString
+    override init() {
+        let random:UInt32 = arc4random() % 2
+        if (random == 0) {
+            imgURL = URL(string: "https://media.gssp.asia/img/bf0/8f2/bf08f28d19c98e2b603a21519a0948f6.png")!
+            title = "title"
+            content = "description sample : ios"
+        } else {
+            imgURL = URL(string: "https://media.gssp.asia/img/bae/bbb/baebbb357d7011d4b1a8fee309dbfe56.jpg")!
+            title = "title"
+            content = "description sample : android"
+        }
+    }
+}
+

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewCell.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  TableViewCell.swift
+//  GNAdSampleNativeAd
+//
+
+import UIKit
+
+class TableViewCell: UITableViewCell {
+
+    @IBOutlet weak var icon: UIImageView!
+    
+    @IBOutlet weak var title: UILabel!
+    
+    @IBOutlet weak var content: UILabel!
+    
+    weak var nativeAd: GNNativeAd!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+
+}

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewController.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewController.swift
@@ -1,10 +1,5 @@
-//
 //  TableViewController.swift
 //  GNAdSampleNativeAd
-//
-//  Created by Tomoyasu Kouta on 2018/06/18.
-//  Copyright © 2018年 Geniee. All rights reserved.
-//
 
 import UIKit
 

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewController.swift
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/GNAdSampleNativeAd/TableViewController.swift
@@ -1,0 +1,228 @@
+//
+//  TableViewController.swift
+//  GNAdSampleNativeAd
+//
+//  Created by Tomoyasu Kouta on 2018/06/18.
+//  Copyright © 2018年 Geniee. All rights reserved.
+//
+
+import UIKit
+
+class TableViewController: UITableViewController, GNNativeAdRequestDelegate {
+    @IBOutlet weak var indicator: UIActivityIndicatorView!
+    var _loading = false
+    var _secondsStart: TimeInterval = 0.0, _secondsEnd: TimeInterval = 0.0
+    var _queueAds = GNQueue(aMaxSize: 100)
+    var _cellDataList = NSMutableArray()
+    // Create GNNativeAdRequest
+    var _nativeAdRequest: GNNativeAdRequest  = GNNativeAdRequest(id:"YOUR APP ID");
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        _secondsStart = NSDate.timeIntervalSinceReferenceDate
+        // Load GNNativeAdRequest
+        _nativeAdRequest.delegate = self;
+        _nativeAdRequest.loadAds()
+        
+        // Uncomment the following line to preserve selection between presentations
+//         self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+//        self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    // MARK: GNNativeAdRequestDelegate
+    func nativeAdRequestDidReceiveAds(_ nativeAds: [Any]!) {
+        _secondsEnd = NSDate.timeIntervalSinceReferenceDate
+        NSLog("TableViewController: nativeAdRequestDidReceiveAds in %f seconds.", (Double)(_secondsEnd - _secondsStart));
+        for nativeAd in nativeAds as! [GNNativeAd] {
+            _queueAds.enqueue(nativeAd)
+        }
+    }
+    
+    func nativeAdRequest(_ request: GNNativeAdRequest!, didFailToReceiveAdsWithError error: Error!) {
+        NSLog("AdRequest Failed: %@", error.localizedDescription)
+    }
+    
+    func shouldStartExternalBrowser(withClick nativeAd: GNNativeAd!, landingURL: String!) -> Bool {
+        NSLog("TableViewController: shouldStartExternalBrowserWithClick : %@.", landingURL)
+        return true
+    }
+    
+
+    // MARK: UITableViewController
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return _cellDataList.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SampleDataCell", for: indexPath) as! TableViewCell
+        
+        if let nativeAd = _cellDataList.object(at: indexPath.row) as? GNNativeAd {
+            cell.nativeAd = nativeAd;
+            cell.title.text = nativeAd.title;
+            cell.content.text = nativeAd.description
+            cell.icon.image = nil;
+            let url = URL(string: nativeAd.icon_url)!
+            requestImageWithURL(url, completion:{(image: UIImage!, error: Error!)->Void in
+                if (error != nil) {
+                    NSLog("Load Image Failed: %@", error.localizedDescription)
+                    return
+                }
+                cell.icon.image = image
+            })
+            nativeAd.trackingImpression(with: cell)
+        } else {
+            let myCellData: MyCellData = _cellDataList.object(at: indexPath.row) as! MyCellData
+            cell.nativeAd = nil
+            cell.title.text = (myCellData.title as String) + " No.\(indexPath.row + 1)"
+            cell.content.text = myCellData.content as String
+            cell.icon.image = nil;
+            let url = myCellData.imgURL
+            requestImageWithURL(url, completion:{(image: UIImage!, error: Error!)->Void in
+                if (error != nil) {
+                    
+                    return
+                }
+                cell.icon.image = image
+            })
+        }
+        return cell
+    }
+    
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let contentOffsetWidthWindow: CGFloat = self.tableView.contentOffset.y + self.tableView.bounds.size.height
+        let heightContent: CGFloat = self.tableView.contentSize.height
+        var leachToBottom = false
+        if contentOffsetWidthWindow >= heightContent {leachToBottom = true}
+        if (!leachToBottom || _loading) {return}
+        indicator.startAnimating()
+        _secondsStart = NSDate.timeIntervalSinceReferenceDate
+        _nativeAdRequest.loadAds()
+        requestCellDataListAsync()
+    }
+
+    func requestImageWithURL(_ url: URL, completion:@escaping (_ image: UIImage?, _ error: Error?)->Void)
+    {
+        let request = URLRequest(url: url)
+        URLSession.shared.dataTask(with:request) {(data, response, error) in
+            if error != nil {completion(nil, error)}
+            guard let data = data else { return }
+            let image = UIImage(data: data)
+            let icon = self.createIconImageWithImage(image: image!)
+            DispatchQueue.main.async {
+                completion(icon, nil)
+            }
+        }.resume()
+    }
+    
+    func createIconImageWithImage(image: UIImage) -> UIImage {
+        let img: UIImage! = resizedImageWithImage(image: image,maxPixel: 100)
+        return roundedImageWithImage(image: img, cornerRadius: 10.0, borderWidth: 1.0);
+    }
+    
+    func resizedImageWithImage(image: UIImage, maxPixel: UInt) -> UIImage! {
+        var w: CGFloat = image.size.width
+        var h: CGFloat = image.size.height
+        if (w == 0 || h == 0) {return nil}
+        
+        let ratio: CGFloat = w / h
+        if (1 < ratio) {
+            if (CGFloat(maxPixel) < w) {
+                w = CGFloat(maxPixel)
+                h = w / ratio
+            }
+        } else {
+            if (CGFloat(maxPixel) < h) {
+                h = CGFloat(maxPixel)
+                w = h * ratio
+            }
+        }
+        
+        var context: CGContext
+        UIGraphicsBeginImageContext(CGSize(width:w, height:h))
+        context = UIGraphicsGetCurrentContext()!
+        context.translateBy(x: 0, y:0)
+        context.rotate(by: 0)
+        
+        context.interpolationQuality = CGInterpolationQuality.high
+        image.draw(in: CGRect(x:0, y:0, width:w, height:h))
+        let resultImage: UIImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        
+        return resultImage
+    }
+
+    func roundedImageWithImage(
+        image: UIImage,
+        cornerRadius: CGFloat,
+            borderWidth: CGFloat) -> UIImage {
+        let maxCornerSize = min(image.size.width, image.size.height) * 0.5;
+        let radius = min(maxCornerSize, cornerRadius)
+        let h: CGFloat = image.size.height
+        let w: CGFloat = image.size.width
+        let cimage = image.cgImage!
+        let pC = cimage.bitsPerComponent;
+        let pR = pC * 4 * Int(w)
+        let colorSpace: CGColorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.noneSkipLast.rawValue
+        let context: CGContext = CGContext(data: nil, width: Int(w), height: Int(h), bitsPerComponent: pC, bytesPerRow: pR, space: colorSpace, bitmapInfo: bitmapInfo)!
+        
+        context.setFillColor(red:1.0, green:1.0, blue:1.0, alpha:1.0)
+        context.fill(CGRect(x:0, y:0, width:w, height:h))
+
+        addRoundedCornerPathWithContext(context, width:w, height:h, cornerRadius:radius)
+        context.clip()
+        context.draw(cimage, in:CGRect(x:0, y:0, width:w, height:h))
+
+        addRoundedCornerPathWithContext(context, width:w, height:h, cornerRadius:radius)
+        context.setStrokeColor(red:0, green:0, blue:0, alpha:1.0)
+        context.setLineWidth(borderWidth)
+        context.strokePath()
+
+        let clippedImage: CGImage! = context.makeImage()
+        let roundedImage: UIImage! = UIImage(cgImage: clippedImage)
+        return roundedImage
+    }
+    
+    func addRoundedCornerPathWithContext(_ context: CGContext, width w: CGFloat, height h: CGFloat, cornerRadius r: CGFloat) {
+        context.beginPath()
+        context.move(to: CGPoint(x:0, y:r))
+        context.addArc(tangent1End: CGPoint(x:0, y:h), tangent2End: CGPoint(x:r, y:h), radius: r)
+        context.addArc(tangent1End: CGPoint(x:w, y:h), tangent2End: CGPoint(x:w, y:h-r), radius: r)
+        context.addArc(tangent1End: CGPoint(x:w, y:0), tangent2End: CGPoint(x:w-r, y:0), radius: r)
+        context.addArc(tangent1End: CGPoint(x:0, y:0), tangent2End: CGPoint(x:0, y:r), radius: r)
+        context.closePath()
+    }
+
+    // MARK get My Cell Data
+    func requestCellDataListAsync()
+    {
+        _loading = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.createCellDataList()
+        }
+    }
+    
+    func createCellDataList() {
+        for _ in 0..<20 {
+            if let ad = _queueAds.dequeue() as Any?  {
+                _cellDataList.add(ad)
+            } else {
+                _cellDataList.add(MyCellData())
+            }
+        }
+        indicator.stopAnimating()
+        self.tableView.reloadData()
+        _loading = false
+    }
+}

--- a/sample/use_cocoapods/swift/GNAdSampleNativeAd/Podfile
+++ b/sample/use_cocoapods/swift/GNAdSampleNativeAd/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'GNAdSampleNativeAd' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  #use_frameworks!
+
+  # Pods for GNAdSampleNativeAd
+  pod 'Geniee-iOS-SDK', :git => 'https://github.com/geniee-ssp/Geniee-iOS-SDK.git', :branch => 'develop'
+
+end


### PR DESCRIPTION
Add swift native ad sample use cocoapods [based on exists code](https://github.com/geniee-ssp/Geniee-iOS-SDK/tree/master/sample/swift/GNAdSampleNativeAd).  

And migrate swift version (2 to 4).
- use `DispatchQueue` instead of `dispatch_***`
- use `URLSession.dataTask` instead of ` NSURLConnection.sendAsynchronousRequest`
- use `CGContext` methods
- replace C-style for loop
- other some fix