### PR TITLE
Conform to newer versions of ad network API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 |SDK| Version |
 |:--|:--|
 |GNAdSDK| 6.0.0 |
-|rewardMediation|3.0.3|
+|rewardMediation|3.1.0|
 |fullscreenMediation|3.0.0|
 |GNAdGoogleMediationAdapter|6.0.0|
 
@@ -22,15 +22,15 @@
 | AD Network　　　　　　　　　　　　　 | Verified version　　　　|
 |:-----------|:------------|
 | [maio](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Maio-For-iOS.html) | 1.4.0 |
-| [AppLovin](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Applovin-For-iOS.html) | 5.1.1 | 
-| [Unity Ads](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-UnityAds-For-iOS.html) | 2.3.0 | 
+| [AppLovin](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Applovin-For-iOS.html) | 6.9.4 | 
+| [Unity Ads](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-UnityAds-For-iOS.html) | 3.3.0 | 
 | [AdColony](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-AdColony-For-iOS.html) | 3.3.5 | 
 | [CAReward](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-CAReward-For-iOS.html) | 2.3.1 | 
-| [Tapjoy](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Tapjoy-For-iOS.html) | 12.2.1 | 
-| [Vungle](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Vungle-For-iOS.html) | 6.2.0 | 
-| [Nend](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Nend-For-iOS.html) | 5.0.2 | 
+| [Tapjoy](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Tapjoy-For-iOS.html) | 12.3.4 | 
+| [Vungle](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Vungle-For-iOS.html) | 6.4.5 | 
+| [Nend](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Nend-For-iOS.html) | 5.3.0 | 
 | [AMoAd](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-Amoad-For-iOS.html) | playable-1.0.0 | 
-| [TikTok](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-TikTok-For-iOS.html) | 1.9.9.5 |
+| [TikTok](https://developers.geniee.co.jp/ios/reward/mediation/RewardVideo-Ad-Integration-ADNW-TikTok-For-iOS.html) | 2.4.6.7 |
 
 ### [Ad Network(Fullscreen interstitial Mediation)](https://developers.geniee.co.jp/ios/fullscreen-interstitial/)
 

--- a/rewardMediation/AdColony/GNSAdapterAdColonyRewardVideoAd.m
+++ b/rewardMediation/AdColony/GNSAdapterAdColonyRewardVideoAd.m
@@ -34,7 +34,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/Amoad/GNSAdapterAmoadRewardVideoAd.m
+++ b/rewardMediation/Amoad/GNSAdapterAmoadRewardVideoAd.m
@@ -36,7 +36,7 @@ static BOOL loggingEnabled = YES;
 #pragma mark - implement GNSAdNetworkConnector
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/AppLovin/GNSAdapterAppLovinRewardVideoAd.m
+++ b/rewardMediation/AppLovin/GNSAdapterAppLovinRewardVideoAd.m
@@ -37,7 +37,7 @@ ALAdDisplayDelegate, ALAdVideoPlaybackDelegate>
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/CAReward/GNSAdapterCARewardRewardVideoAd.m
+++ b/rewardMediation/CAReward/GNSAdapterCARewardRewardVideoAd.m
@@ -32,7 +32,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/Maio/GNSAdapterMaioRewardVideoAd.m
+++ b/rewardMediation/Maio/GNSAdapterMaioRewardVideoAd.m
@@ -33,7 +33,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/Nend/GNSAdapterNendRewardVideoAd.m
+++ b/rewardMediation/Nend/GNSAdapterNendRewardVideoAd.m
@@ -36,7 +36,7 @@ static BOOL loggingEnabled = YES;
 #pragma mark - implement GNSRewardVideoAdNetworkConnector
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/Tapjoy/GNSAdapterTapjoyRewardVideoAd.m
+++ b/rewardMediation/Tapjoy/GNSAdapterTapjoyRewardVideoAd.m
@@ -39,7 +39,7 @@ static BOOL establishingConnection = NO;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/TikTok/GNSAdapterTikTokRewardVideoAd.m
+++ b/rewardMediation/TikTok/GNSAdapterTikTokRewardVideoAd.m
@@ -36,7 +36,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {
@@ -118,7 +118,6 @@ static BOOL loggingEnabled = YES;
     
     BURewardedVideoModel *model = [[BURewardedVideoModel alloc] init];
     model.userId = @"geniee";
-    model.isShowDownloadBar = NO;
     self.rewardedVideoAd = [[BURewardedVideoAd alloc] initWithSlotID:extras.slotId rewardedVideoModel:model];
     self.rewardedVideoAd.delegate = self;
     [self.rewardedVideoAd loadAdData];
@@ -173,8 +172,6 @@ static BOOL loggingEnabled = YES;
 
 - (void)rewardedVideoAdDidClick:(BURewardedVideoAd *)rewardedVideoAd {
     [self ALLog:@"rewardedVideoAd video did click"];
-    
-    [self.connector adapterDidClickAd:self];
 }
 
 - (void)rewardedVideoAd:(BURewardedVideoAd *)rewardedVideoAd didFailWithError:(NSError *)error {

--- a/rewardMediation/UnityAds/GNSAdapterUnityAdsRewardVideoAd.m
+++ b/rewardMediation/UnityAds/GNSAdapterUnityAdsRewardVideoAd.m
@@ -33,7 +33,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/rewardMediation/Vungle/GNSAdapterVungleRewardVideoAd.m
+++ b/rewardMediation/Vungle/GNSAdapterVungleRewardVideoAd.m
@@ -38,7 +38,7 @@ static BOOL loggingEnabled = YES;
 }
 
 + (NSString *)adapterVersion {
-    return @"3.0.3";
+    return @"3.1.0";
 }
 
 + (Class<GNSAdNetworkExtras>)networkExtrasClass {

--- a/sample/use_cocoapods/objectivec/GNAdGoogleRewardMediationAdapterSample/Podfile
+++ b/sample/use_cocoapods/objectivec/GNAdGoogleRewardMediationAdapterSample/Podfile
@@ -7,12 +7,12 @@ target 'GNAdGoogleRewardMediationAdapterSample' do
   pod 'Geniee-iOS-SDK'
   pod 'Geniee-Google-Mediation-Adapter'
   pod 'AdColony', '~> 3.3.5'
-  pod 'AppLovinSDK','~> 5.1.1'
+  pod 'AppLovinSDK','~> 6.9.4'
   pod 'MaioSDK', '~> 1.4.0'
-  pod 'NendSDK_iOS', '~> 5.0.2'
-  pod 'TapjoySDK', '~> 12.2.1'
-  pod 'UnityAds', '~> 2.3.0'
-  pod 'VungleSDK-iOS', '~> 6.2.0'
-  pod 'Bytedance-UnionAD', '~> 1.9.9.5'
+  pod 'NendSDK_iOS', '~> 5.3.0'
+  pod 'TapjoySDK', '~> 12.3.4'
+  pod 'UnityAds', '~> 3.3.0'
+  pod 'VungleSDK-iOS', '~> 6.4.5'
+  pod 'Bytedance-UnionAD', '~> 2.4.6.7'
 
 end

--- a/sample/use_cocoapods/objectivec/GNAdRewardVideoSample/Podfile
+++ b/sample/use_cocoapods/objectivec/GNAdRewardVideoSample/Podfile
@@ -8,12 +8,12 @@ target 'GNAdRewardVideoSample' do
   # Pods for GNAdRewardVideoSample
   pod 'Geniee-iOS-SDK'
   pod 'AdColony', '~> 3.3.5'
-  pod 'AppLovinSDK','~> 5.1.1'
+  pod 'AppLovinSDK','~> 6.9.4'
   pod 'MaioSDK', '~> 1.4.0'
-  pod 'NendSDK_iOS', '~> 5.0.2'
-  pod 'TapjoySDK', '~> 12.2.1'
-  pod 'UnityAds', '~> 2.3.0'
-  pod 'VungleSDK-iOS', '~> 6.2.0'
-  pod 'Bytedance-UnionAD', '~> 1.9.9.5'
+  pod 'NendSDK_iOS', '~> 5.3.0'
+  pod 'TapjoySDK', '~> 12.3.4'
+  pod 'UnityAds', '~> 3.3.0'
+  pod 'VungleSDK-iOS', '~> 6.4.5'
+  pod 'Bytedance-UnionAD', '~> 2.4.6.7'
 
 end

--- a/sample/use_cocoapods/swift/GNAdGoogleRewardAdapterSample/Podfile
+++ b/sample/use_cocoapods/swift/GNAdGoogleRewardAdapterSample/Podfile
@@ -8,12 +8,12 @@ target 'GNAdGoogleRewardAdapterSample' do
   pod 'Geniee-iOS-SDK'
   pod 'Geniee-Google-Mediation-Adapter'
   pod 'AdColony', '~> 3.3.5'
-  pod 'AppLovinSDK','~> 5.1.1'
+  pod 'AppLovinSDK','~> 6.9.4'
   pod 'MaioSDK', '~> 1.4.0'
-  pod 'NendSDK_iOS', '~> 5.0.2'
-  pod 'TapjoySDK', '~> 12.2.1'
-  pod 'UnityAds', '~> 2.3.0'
-  pod 'VungleSDK-iOS', '~> 6.2.0'
-  pod 'Bytedance-UnionAD', '~> 1.9.9.5'
+  pod 'NendSDK_iOS', '~> 5.3.0'
+  pod 'TapjoySDK', '~> 12.3.4'
+  pod 'UnityAds', '~> 3.3.0'
+  pod 'VungleSDK-iOS', '~> 6.4.5'
+  pod 'Bytedance-UnionAD', '~> 2.4.6.7'
 
 end

--- a/sample/use_cocoapods/swift/GNAdRewardVideoSample/Podfile
+++ b/sample/use_cocoapods/swift/GNAdRewardVideoSample/Podfile
@@ -6,12 +6,12 @@ target 'GNAdRewardVideoSample' do
   #use_frameworks!
   pod 'Geniee-iOS-SDK'
   pod 'AdColony', '~> 3.3.5'
-  pod 'AppLovinSDK','~> 5.1.1'
+  pod 'AppLovinSDK','~> 6.9.4'
   pod 'MaioSDK', '~> 1.4.0'
-  pod 'NendSDK_iOS', '~> 5.0.2'
-  pod 'TapjoySDK', '~> 12.2.1'
-  pod 'UnityAds', '~> 2.3.0'
-  pod 'VungleSDK-iOS', '~> 6.2.0'
-  pod 'Bytedance-UnionAD', '~> 1.9.9.5'
+  pod 'NendSDK_iOS', '~> 5.3.0'
+  pod 'TapjoySDK', '~> 12.3.4'
+  pod 'UnityAds', '~> 3.3.0'
+  pod 'VungleSDK-iOS', '~> 6.4.5'
+  pod 'Bytedance-UnionAD', '~> 2.4.6.7'
   
 end


### PR DESCRIPTION
This includes updates to conform to the following ad networks:
    
    - AppLovin SDK 5.1.1 -> 6.9.4
    - TikTok SDK update 1.9.9.5 -> 2.4.6.7
    - Nend SDK 5.0.2 -> 5.3.0
    - Tapjoy SDK update 12.0.0 -> 12.3.4
    - UnityAds SDK update 2.3.0 -> 3.3.0
    - Vungle SDK 6.2.0 -> 6.4.5